### PR TITLE
Training Programs Get Routes

### DIFF
--- a/controllers/training_program_ctrl.js
+++ b/controllers/training_program_ctrl.js
@@ -1,0 +1,49 @@
+const { get_all, get_all_employees, get_one, get_one_employees, get_employee_programs } = require('../models/Training_Programs');
+
+// GET ALL TRAINING PROGRAMS
+module.exports.get_training_programs = (req, res, next) => {
+    get_all()
+        .then((programs) => {
+            res.status(200).json(programs);
+        })
+        .catch((err) => next(err));
+};
+
+//GET ALL TRAINING PROGRAMS WITH LIST OF EMPLOYEES 
+module.exports.get_training_employees = (req, res, next) => {
+    get_all_employees()
+        .then((employees) => {
+            res.status(200).json(employees);
+        })
+        .catch((err) => next(err));
+};
+
+//GET ONE TRAINING PROGRAM
+module.exports.get_one_training_program = (req, res, next) => {
+    let id = req.params.id;
+    get_one(id)
+        .then((program) => {
+            res.status(200).json(program);
+        })
+        .catch((err) => next(err));
+};
+
+//GET ONE TRAINING PROGRAM'S LIST OF EMPLOYEES
+module.exports.get_one_training_employees = (req, res, next) => {
+    let id = req.params.id;
+    get_one_employees(id)
+        .then((program) => {
+            res.status(200).json(program);
+        })
+        .catch((err) => next(err));
+};
+
+//GET ONE EMPLOYEE'S LIST OF TRAINING PROGRAMS
+module.exports.get_employee_programs_list = (req, res, next) => {
+    let id = req.params.id;
+    get_employee_programs(id)
+        .then((program) => {
+            res.status(200).json(program);
+        })
+        .catch((err) => next(err));
+    };

--- a/models/Training_Programs.js
+++ b/models/Training_Programs.js
@@ -1,0 +1,81 @@
+
+const sqlite3 = require('sqlite3').verbose();
+const db = new sqlite3.Database('./db/squirrely_ducks.sqlite');
+
+// GET ALL TRAINING PROGRAMS
+module.exports.get_all = () => {
+    return new Promise((resolve, reject) => {
+        db.all(`SELECT * 
+        FROM training_program`, 
+        (err, programs) => {
+            if (err) return reject(err);
+            resolve(programs);
+        });
+    });
+};
+
+//GET ALL TRAINING PROGRAMS WITH LIST OF EMPLOYEES 
+module.exports.get_all_employees = () => {
+    return new Promise((resolve, reject) => {
+        db.all(`SELECT training_program.*, group_concat(employee.first_name || " " || employee.last_name, ", ") AS "employees"
+        FROM employee_training
+        JOIN employee
+        ON employee.employee_id = employee_training.employee_id
+        JOIN training_program
+        ON training_program.training_id = employee_training.program_id
+        GROUP BY training_program.training_id`, 
+        (err, programs) => {
+            if (err) return reject(err);
+            resolve(programs);
+        });
+    });
+};
+
+
+//GET ONE TRAINING PROGRAM
+module.exports.get_one = (id) => {
+    return new Promise((resolve, reject) => {
+        db.all(`SELECT * 
+        FROM training_program tp
+        WHERE tp.training_id = ${id}`, 
+        (err, programs) => {
+            if (err) return reject(err);
+            resolve(programs);
+        });
+    });
+};
+
+//GET ONE TRAINING PROGRAM'S LIST OF EMPLOYEES
+module.exports.get_one_employees = (id) => {
+    return new Promise((resolve, reject) => {
+        db.all(`SELECT training_program.*, group_concat(employee.first_name || " " || employee.last_name, ", ") AS "employees"
+        FROM employee_training
+        JOIN employee
+        ON employee.employee_id = employee_training.employee_id
+        JOIN training_program
+        ON training_program.training_id = employee_training.program_id
+        WHERE training_program.training_id = ${id}`, 
+        (err, program) => {
+            if (err) return reject(err);
+            resolve(program);
+        });
+    });
+};
+
+//GET ONE EMPLOYEE'S LIST OF TRAINING PROGRAMS
+module.exports.get_employee_programs = (id) => {
+    return new Promise((resolve, reject) => {
+        db.all(`SELECT employee.first_name || " " || employee.last_name AS "employee", 
+        group_concat(training_program.name, ", ") AS "training_programs"
+        FROM employee_training
+        JOIN employee
+        ON employee.employee_id = employee_training.employee_id
+        JOIN training_program
+        ON training_program.training_id = employee_training.program_id
+        WHERE employee.employee_id = ${id}`, 
+        (err, program) => {
+            if (err) return reject(err);
+            resolve(program);
+        });
+    });
+};

--- a/models/Training_Programs.js
+++ b/models/Training_Programs.js
@@ -75,7 +75,6 @@ module.exports.get_employee_programs = (id) => {
         WHERE employee.employee_id = ${id}`, 
         (err, program) => {
             if (err) return reject(err);
-            console.log('Program', program);
             if (program[0].employee === null) {
                 resolve({"message": "This employee is not enrolled in any programs"});
             }
@@ -84,18 +83,3 @@ module.exports.get_employee_programs = (id) => {
     });
 };
 
-// ADD NEW TRAINING PROGRAM
-module.exports.new_training_program = ({ name, start_date, end_date, capacity}) => {
-    return new Promise((resolve, reject) => {
-        db.run(`INSERT INTO training_program VALUES (
-            null,
-            "${name}",
-            "${start_date}",
-            "${end_date}",
-            ${capacity}
-        )`, function(err) {
-            if (err) reject(err);
-            resolve(this.lastID);
-        });
-    });
-};

--- a/models/Training_Programs.js
+++ b/models/Training_Programs.js
@@ -14,7 +14,7 @@ module.exports.get_all = () => {
     });
 };
 
-//GET ALL TRAINING PROGRAMS WITH LIST OF EMPLOYEES 
+// GET ALL TRAINING PROGRAMS WITH LIST OF EMPLOYEES 
 module.exports.get_all_employees = () => {
     return new Promise((resolve, reject) => {
         db.all(`SELECT training_program.*, group_concat(employee.first_name || " " || employee.last_name, ", ") AS "employees"
@@ -32,7 +32,7 @@ module.exports.get_all_employees = () => {
 };
 
 
-//GET ONE TRAINING PROGRAM
+// GET ONE TRAINING PROGRAM
 module.exports.get_one = (id) => {
     return new Promise((resolve, reject) => {
         db.all(`SELECT * 
@@ -45,7 +45,7 @@ module.exports.get_one = (id) => {
     });
 };
 
-//GET ONE TRAINING PROGRAM'S LIST OF EMPLOYEES
+// GET ONE TRAINING PROGRAM'S LIST OF EMPLOYEES
 module.exports.get_one_employees = (id) => {
     return new Promise((resolve, reject) => {
         db.all(`SELECT training_program.*, group_concat(employee.first_name || " " || employee.last_name, ", ") AS "employees"
@@ -62,7 +62,7 @@ module.exports.get_one_employees = (id) => {
     });
 };
 
-//GET ONE EMPLOYEE'S LIST OF TRAINING PROGRAMS
+// GET ONE EMPLOYEE'S LIST OF TRAINING PROGRAMS
 module.exports.get_employee_programs = (id) => {
     return new Promise((resolve, reject) => {
         db.all(`SELECT employee.first_name || " " || employee.last_name AS "employee", 
@@ -75,7 +75,27 @@ module.exports.get_employee_programs = (id) => {
         WHERE employee.employee_id = ${id}`, 
         (err, program) => {
             if (err) return reject(err);
+            console.log('Program', program);
+            if (program[0].employee === null) {
+                resolve({"message": "This employee is not enrolled in any programs"});
+            }
             resolve(program);
+        });
+    });
+};
+
+// ADD NEW TRAINING PROGRAM
+module.exports.new_training_program = ({ name, start_date, end_date, capacity}) => {
+    return new Promise((resolve, reject) => {
+        db.run(`INSERT INTO training_program VALUES (
+            null,
+            "${name}",
+            "${start_date}",
+            "${end_date}",
+            ${capacity}
+        )`, function(err) {
+            if (err) reject(err);
+            resolve(this.lastID);
         });
     });
 };

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,5 +6,6 @@ router.use(require('./customers'));
 router.use(require('./products'));
 router.use(require('./payment_types'));
 router.use(require('./employees'));
+router.use(require('./training_programs'));
 
 module.exports = router;

--- a/routes/training_programs.js
+++ b/routes/training_programs.js
@@ -1,0 +1,18 @@
+const { Router } = require("express");
+const trainingProgramRouter = Router();
+const { get_training_programs, get_training_employees, get_one_training_program, get_one_training_employees, get_employee_programs_list } = require('../controllers/training_program_ctrl');
+
+
+// GET ALL TRAINING PROGRAMS
+trainingProgramRouter.get("/training_programs", get_training_programs);
+//GET ALL TRAINING PROGRAMS WITH LIST OF EMPLOYEES 
+trainingProgramRouter.get("/training_programs/employees", get_training_employees);
+//GET ONE TRAINING PROGRAM
+trainingProgramRouter.get("/training_programs/:id", get_one_training_program);
+//GET ONE TRAINING PROGRAM'S LIST OF EMPLOYEES
+trainingProgramRouter.get("/training_programs/program/:id", get_one_training_employees);
+//GET ONE EMPLOYEE'S LIST OF TRAINING PROGRAMS
+trainingProgramRouter.get("/training_programs/employee/:id", get_employee_programs_list);
+
+
+module.exports = trainingProgramRouter;


### PR DESCRIPTION
## DESCRIPTION
Added get routes for Training Programs. Ability to get: 
1. Get all training programs 
2. Get one training program,  
3. List of employees in each program
4. List of employees in one program
5. Get list of training programs for one employee

Necessary get routes for function of API

## STEPS TO TEST
1. Install npm
```javascript
$ npm install
```
2. Rebuild database if neccessary
```javascript
node data/execute_data.js
node db/build_db.js
```
3. To get list of all training programs:
<http://localhost:4200/api/v1/training_programs>

4. To get list of training programs with enrolled employees:
<http://localhost:4200/api/v1/training_programs/employees>

5. To get one training program:
<http://localhost:4200/api/v1/training_programs/1>

6. To get one training program with enrolled employees:
<http://localhost:4200/api/v1/training_programs/program/3>
If null is returned, try a different program id for one that has employees:
```javascript
http://localhost:4200/api/v1/training_programs/program/:id
```
7. To get list of enrolled training programs by one employee:
```javascript
http://localhost:4200/api/v1/training_programs/program/:id
```

## REFERENCE
[Ticket - Get Routes for Training Programs](https://github.com/Squirrely-Ducks/bangazon-api-sprint-1/projects/1#card-8414975)
[Issue - Allow developers to access the Training Program resource](#9)
